### PR TITLE
Refactor services to use participant IDs

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -146,7 +146,7 @@ async def admin_tx_approve(callback: CallbackQuery):
     await callback.bot.send_message(participant.telegram_id, text)
 
     # Build the participant menu and send it
-    menu_text, menu_kb = await build_participant_menu(participant.telegram_id)
+    menu_text, menu_kb = await build_participant_menu(participant.id)
     await callback.bot.send_message(participant.telegram_id, menu_text, reply_markup=menu_kb)
 
     # Mark the admin’s notification as handled
@@ -181,7 +181,7 @@ async def admin_tx_decline(callback: CallbackQuery):
     await callback.bot.send_message(participant.telegram_id, text)
 
     # Build the participant menu and send it
-    menu_text, menu_kb = await build_participant_menu(participant.telegram_id)
+    menu_text, menu_kb = await build_participant_menu(participant.id)
     await callback.bot.send_message(participant.telegram_id, menu_text, reply_markup=menu_kb)
 
     # Mark the admin’s notification as handled


### PR DESCRIPTION
## Summary
- Replace telegram-based lookups with participant_id in banking and menu services
- Update participant and admin handlers to pass participant_id from FSM context
- Drop redundant get_participant_by_telegram_id calls

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68950270c32883338ae6856b1376c226