### PR TITLE
Add savings and loan functionality with interest accrual

### DIFF
--- a/database/crud_courses.py
+++ b/database/crud_courses.py
@@ -12,14 +12,22 @@ async def create_course(
         name: str,
         description: str,
         creator_id: int,
-        sheet_url: str | None = None
+        sheet_url: str | None = None,
+        max_loan_amount: float = 100,
+        savings_withdrawal_delay: int = 7,
+        interest_day: int = 0,
+        interest_time: str = "09:00",
 ) -> Course:
     """Create and commit a new course record."""
     course = Course(
         name=name,
         description=description,
         sheet_url=sheet_url,
-        creator_id=creator_id
+        creator_id=creator_id,
+        max_loan_amount=max_loan_amount,
+        savings_withdrawal_delay=savings_withdrawal_delay,
+        interest_day=interest_day,
+        interest_time=interest_time,
     )
     session.add(course)
     await session.commit()

--- a/database/models.py
+++ b/database/models.py
@@ -21,6 +21,12 @@ class Course(Base):
     is_active = Column(Boolean, default=True)
     finish_date = Column(DateTime, nullable=True)
 
+    # Course-wide financial settings
+    max_loan_amount = Column(Numeric(8, 2), default=100)  # maximum total loan per participant
+    savings_withdrawal_delay = Column(Integer, default=7)  # days lock after deposit
+    interest_day = Column(Integer, default=0)  # 0=Monday ... 6=Sunday
+    interest_time = Column(String, default="09:00")  # HH:MM in UTC
+
     # Relationship to participants
     participants = relationship("Participant", back_populates="course")
 
@@ -40,6 +46,9 @@ class Participant(Base):
     balance = Column(Numeric(8, 2), default=0)
     savings_balance = Column(Numeric(8, 2), default=0)
     loan_balance = Column(Numeric(8, 2), default=0)
+
+    # timestamp of last deposit to savings to enforce withdrawal delay
+    last_savings_deposit_at = Column(DateTime, nullable=True)
 
     course = relationship("Course", back_populates="participants")
     transactions = relationship("Transaction", back_populates="participant")

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -13,6 +13,9 @@ LEXICON = {
     # Prompts for creating a new course
     "course_name_request": "Enter the name of the new course:",  # Ask admin for course title
     "course_description_request": "Enter the description of the course:",  # Ask admin for course description
+    "course_savings_rate_request": "Enter weekly savings interest rate (%)",
+    "course_loan_rate_request": "Enter weekly loan interest rate (%)",
+    "course_rate_invalid": "Please enter a valid percentage.",
     "course_sheet_request": "Please send the Google Sheets link containing the list of participants:",
     # Ask for sheet URL
 
@@ -74,6 +77,10 @@ LEXICON = {
         "📝 Description: {description}\n"
         "🗓 Created: {created_at:%d.%m.%Y}\n"
         "{course_status_emoji} Status: {status}\n\n"
+        "💹 Savings rate: {savings_rate}%\n"
+        "💸 Loan rate: {loan_rate}%\n"
+        "💳 Max loan: {max_loan}\n"
+        "⏳ Savings lock: {savings_delay} days\n\n"
         "👥 Total participants: {total}\n"
         "📝 Registered: {registered}\n"
         "💰 Average balance: {avg_balance:.2f}"
@@ -95,7 +102,9 @@ LEXICON = {
         "👤 {name}\n\n"
         "💳 Balance: {balance}\n"
         "📥 Savings: {savings}\n"
-        "🤑 Loans: {loan}"
+        "🤑 Loans: {loan}\n\n"
+        "📈 Savings rate: {savings_rate}%\n"
+        "💸 Loan rate: {loan_rate}%"
     ),  # Overview of participant balances
 
     # Inline Keyboard Buttons
@@ -116,6 +125,19 @@ LEXICON = {
 
     "invalid_amount": "Please enter a valid positive number.",
     "insufficient_funds": "You have insufficient funds.\nEnter the amount to withdraw 🪙:",
+
+    # Savings and loans operations
+    "to_savings_amount_request": "Enter amount to transfer to savings 🪙:",
+    "from_savings_amount_request": "Enter amount to withdraw from savings 🪙:",
+    "take_loan_amount_request": "Enter loan amount 🪙:",
+    "repay_loan_amount_request": "Enter amount to repay 🪙:",
+    "savings_deposit_success": "✅ {amount} 🪙 moved to savings.",
+    "savings_withdraw_success": "✅ {amount} 🪙 withdrawn from savings.",
+    "loan_take_success": "✅ Loan of {amount} 🪙 issued.",
+    "loan_repay_success": "✅ Loan repaid by {amount} 🪙.",
+    "savings_locked": "⏳ Savings are locked for {days} days after deposit.",
+    "savings_insufficient": "You don't have that much in savings.",
+    "loan_limit_reached": "Loan limit is {limit} 🪙.",
 
     "withdraw_waiting_approval": "Your withdrawal request of {amount} 🪙 is pending operator approval.\n(tx_id: {tx_id})",
     "deposit_waiting_approval": "Your deposit request of {amount} 🪙 is pending operator approval.\n(tx_id: {tx_id})",

--- a/services/banking.py
+++ b/services/banking.py
@@ -1,10 +1,19 @@
 # services/banking.py
 
 import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
 
 from database.base import AsyncSessionLocal
 from database.crud_transactions import create_transaction, update_transaction_status
-from database.models import Participant, Transaction
+from database.crud_participant import (
+    adjust_participant_balance,
+    adjust_savings_balance,
+    adjust_loan_balance,
+)
+from database.crud_courses import get_current_rate
+from database.models import Participant, Transaction, Course
 from lexicon.lexicon_en import LEXICON
 
 logger = logging.getLogger(__name__)
@@ -72,3 +81,129 @@ async def cancel_transaction(
     logger.info(f"Transaction canceled by participant: tx_id={tx_id}, participant_id={participant_id}")
 
 # endregion --- Cash Transactions ---
+
+
+# region --- Savings and Loans ---
+
+async def move_to_savings(participant_id: int, amount: int) -> None:
+    """Transfer amount from main balance to savings immediately."""
+    async with AsyncSessionLocal() as session:
+        participant = await session.get(Participant, participant_id)
+        if amount <= 0:
+            raise ValueError(LEXICON["invalid_amount"])
+        if amount > participant.balance:
+            raise ValueError(LEXICON["insufficient_funds"])
+
+        await adjust_participant_balance(session, participant, -amount)
+        await adjust_savings_balance(session, participant, amount)
+        await create_transaction(
+            session,
+            participant_id=participant_id,
+            tx_type="savings_deposit",
+            amount=amount,
+            status="completed",
+        )
+
+
+async def withdraw_from_savings(participant_id: int, amount: int) -> None:
+    """Move funds from savings back to main balance respecting lock period."""
+    async with AsyncSessionLocal() as session:
+        participant = await session.get(Participant, participant_id)
+        course = await session.get(Course, participant.course_id)
+        if amount <= 0:
+            raise ValueError(LEXICON["invalid_amount"])
+        if amount > participant.savings_balance:
+            raise ValueError(LEXICON["savings_insufficient"])
+        last = participant.last_savings_deposit_at
+        if last and datetime.utcnow() - last < timedelta(days=course.savings_withdrawal_delay):
+            raise ValueError(
+                LEXICON["savings_locked"].format(days=course.savings_withdrawal_delay)
+            )
+
+        await adjust_savings_balance(session, participant, -amount)
+        await adjust_participant_balance(session, participant, amount)
+        await create_transaction(
+            session,
+            participant_id=participant_id,
+            tx_type="savings_withdraw",
+            amount=amount,
+            status="completed",
+        )
+
+
+async def take_loan(participant_id: int, amount: int) -> None:
+    """Issue a loan to participant up to course limit."""
+    async with AsyncSessionLocal() as session:
+        participant = await session.get(Participant, participant_id)
+        course = await session.get(Course, participant.course_id)
+        if amount <= 0:
+            raise ValueError(LEXICON["invalid_amount"])
+        if participant.loan_balance + amount > course.max_loan_amount:
+            raise ValueError(
+                LEXICON["loan_limit_reached"].format(limit=course.max_loan_amount)
+            )
+
+        await adjust_loan_balance(session, participant, amount)
+        await adjust_participant_balance(session, participant, amount)
+        await create_transaction(
+            session,
+            participant_id=participant_id,
+            tx_type="loan_borrow",
+            amount=amount,
+            status="completed",
+        )
+
+
+async def repay_loan(participant_id: int, amount: int) -> None:
+    """Repay part of the loan from main balance."""
+    async with AsyncSessionLocal() as session:
+        participant = await session.get(Participant, participant_id)
+        if amount <= 0:
+            raise ValueError(LEXICON["invalid_amount"])
+        if amount > participant.balance:
+            raise ValueError(LEXICON["insufficient_funds"])
+        repay = min(amount, participant.loan_balance)
+
+        await adjust_participant_balance(session, participant, -repay)
+        await adjust_loan_balance(session, participant, -repay)
+        await create_transaction(
+            session,
+            participant_id=participant_id,
+            tx_type="loan_repay",
+            amount=repay,
+            status="completed",
+        )
+
+
+async def apply_weekly_interest(course_id: int) -> None:
+    """Apply weekly interest for all participants of a course."""
+    async with AsyncSessionLocal() as session:
+        savings_rate = await get_current_rate(session, course_id, "savings")
+        loan_rate = await get_current_rate(session, course_id, "loan")
+        result = await session.execute(
+            select(Participant).where(Participant.course_id == course_id)
+        )
+        participants = result.scalars().all()
+        for p in participants:
+            if savings_rate and p.savings_balance > 0:
+                interest = float(p.savings_balance) * savings_rate / 100
+                await adjust_savings_balance(session, p, interest)
+                await create_transaction(
+                    session,
+                    participant_id=p.id,
+                    tx_type="savings_interest",
+                    amount=interest,
+                    status="completed",
+                )
+            if loan_rate and p.loan_balance > 0:
+                interest = float(p.loan_balance) * loan_rate / 100
+                await adjust_loan_balance(session, p, interest)
+                await create_transaction(
+                    session,
+                    participant_id=p.id,
+                    tx_type="loan_interest",
+                    amount=interest,
+                    status="completed",
+                )
+
+# endregion --- Savings and Loans ---

--- a/services/course_creation_flow.py
+++ b/services/course_creation_flow.py
@@ -24,6 +24,30 @@ async def process_course_name(message: types.Message, state: FSMContext) -> None
 
 async def process_course_description(message: types.Message, state: FSMContext) -> None:
     await state.update_data(description=message.text.strip())
+    await message.answer(LEXICON["course_savings_rate_request"], parse_mode="HTML",)
+    await state.set_state(CourseCreation.waiting_for_savings_rate)
+
+
+async def process_savings_rate(message: types.Message, state: FSMContext) -> None:
+    text = message.text.replace(",", ".").strip()
+    try:
+        rate = float(text)
+    except ValueError:
+        await message.answer(LEXICON["course_rate_invalid"], parse_mode="HTML",)
+        return
+    await state.update_data(savings_rate=rate)
+    await message.answer(LEXICON["course_loan_rate_request"], parse_mode="HTML",)
+    await state.set_state(CourseCreation.waiting_for_loan_rate)
+
+
+async def process_loan_rate(message: types.Message, state: FSMContext) -> None:
+    text = message.text.replace(",", ".").strip()
+    try:
+        rate = float(text)
+    except ValueError:
+        await message.answer(LEXICON["course_rate_invalid"], parse_mode="HTML",)
+        return
+    await state.update_data(loan_rate=rate)
     await message.answer(LEXICON["course_sheet_request"], parse_mode="HTML",)
     await state.set_state(CourseCreation.waiting_for_sheet)
 
@@ -53,6 +77,8 @@ async def process_course_sheet(message: types.Message, state: FSMContext) -> Non
         creator_id=message.from_user.id,
         sheet_url=sheet_url,
         participants_raw=participants_raw,
+        savings_rate=data.get("savings_rate", 0),
+        loan_rate=data.get("loan_rate", 0),
     )
 
     # 3) пишем коды обратно в Google Sheet

--- a/services/course_service.py
+++ b/services/course_service.py
@@ -1,6 +1,6 @@
 # services/course_service.py
 
-from database.crud_courses import create_course, add_participants
+from database.crud_courses import create_course, add_participants, set_rate
 from services.utils import gen_registration_code
 from database.base import AsyncSessionLocal
 from database.models import Participant, Course
@@ -13,6 +13,8 @@ async def create_course_with_participants(
         creator_id: int,
         sheet_url: str,
         participants_raw: list[tuple[str, str]],
+        savings_rate: float,
+        loan_rate: float,
 ) -> tuple[Course, dict[str, str]]:
     """
     1) Берёт сырые данные [(name,email),…] из Google Sheet
@@ -45,5 +47,7 @@ async def create_course_with_participants(
             sheet_url=sheet_url
         )
         await add_participants(session, course.id, participants)
+        await set_rate(session, course.id, "savings", savings_rate)
+        await set_rate(session, course.id, "loan", loan_rate)
 
     return course, codes_map

--- a/services/participant_menu.py
+++ b/services/participant_menu.py
@@ -2,6 +2,7 @@ from aiogram.types import InlineKeyboardMarkup
 
 from database.base import AsyncSessionLocal
 from database.models import Participant
+from database.crud_courses import get_current_rate
 
 from keyboards.participant import main_menu_participant_kb
 
@@ -23,13 +24,17 @@ async def build_participant_menu(
         balance = participant.balance
         savings = participant.savings_balance
         loan = participant.loan_balance
+        savings_rate = await get_current_rate(session, participant.course_id, "savings")
+        loan_rate = await get_current_rate(session, participant.course_id, "loan")
 
     text = LEXICON["main_balance_text"].format(
         name=participant_name,
         course_name=course_name,
         balance=balance,
         savings=savings,
-        loan=loan
+        loan=loan,
+        savings_rate=savings_rate,
+        loan_rate=loan_rate
     )
     kb = main_menu_participant_kb()
     return text, kb

--- a/services/presenters.py
+++ b/services/presenters.py
@@ -1,13 +1,14 @@
 from lexicon.lexicon_en import LEXICON
 
-def render_course_info(course, stats: dict) -> str:
+
+def render_course_info(course, stats: dict, savings_rate: float, loan_rate: float) -> str:
     """
     Собирает текст карточки курса.
     Подставляет:
       - course.created_at  (дата создания)
       - course_status_emoji (в зависимости от course.is_active)
       - status             (текст статуса из лексикона)
-      - остальное из stats
+      - остальное из stats и текущие ставки
     """
     # Выбираем эмодзи
     course_status_emoji = (
@@ -23,12 +24,16 @@ def render_course_info(course, stats: dict) -> str:
     )
     # Собираем
     return LEXICON["course_info"].format(
-        name                = course.name,
-        description         = course.description,
-        created_at          = course.created_at,
-        course_status_emoji = course_status_emoji,
-        status              = status,
-        total               = stats["total"],
-        registered          = stats["registered"],
-        avg_balance         = stats["avg_balance"],
+        name=course.name,
+        description=course.description,
+        created_at=course.created_at,
+        course_status_emoji=course_status_emoji,
+        status=status,
+        total=stats["total"],
+        registered=stats["registered"],
+        avg_balance=stats["avg_balance"],
+        savings_rate=savings_rate,
+        loan_rate=loan_rate,
+        max_loan=course.max_loan_amount,
+        savings_delay=course.savings_withdrawal_delay,
     )

--- a/states/fsm.py
+++ b/states/fsm.py
@@ -3,6 +3,8 @@ from aiogram.fsm.state import StatesGroup, State
 class CourseCreation(StatesGroup):
     waiting_for_name = State()
     waiting_for_description = State()
+    waiting_for_savings_rate = State()
+    waiting_for_loan_rate = State()
     waiting_for_sheet = State()
 
 class Registration(StatesGroup):
@@ -14,4 +16,8 @@ class CourseFinish(StatesGroup):
 class CashOperations(StatesGroup):
     waiting_for_withdraw_amount = State()
     waiting_for_deposit_amount = State()
+    waiting_for_savings_deposit_amount = State()
+    waiting_for_savings_withdraw_amount = State()
+    waiting_for_take_loan_amount = State()
+    waiting_for_repay_loan_amount = State()
     waiting_for_approval = State()


### PR DESCRIPTION
## Summary
- track course-level savings/loan rates and limits including lock period and weekly accrual settings
- allow participants to transfer to/from savings and take or repay loans
- show current rates in course and participant menus and support rate input during course creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689634a1bf1883338291973c72f7968c