### PR TITLE
refactor: improve savings and loan messaging

### DIFF
--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -134,6 +134,8 @@ LEXICON = {
     "loan_take_success": "✅ Loan of {amount} 🪙 issued.",
     "loan_repay_success": "✅ Loan repaid by {amount} 🪙.",
     "savings_locked": "⏳ Savings are locked for {days} days after deposit.",
+    "savings_locked_until": "⏳ Savings are locked until {unlock_time:%d.%m.%Y %H:%M UTC}.",
+    "savings_lock_warning": "⚠️ After deposit, funds cannot be withdrawn for {days} days (until {unlock_time:%d.%m.%Y %H:%M UTC}).",
     "savings_insufficient": "You don't have that much in savings.",
     "loan_limit_reached": "Loan limit is {limit} 🪙.",
 


### PR DESCRIPTION
## Summary
- warn about savings lock duration with precise unlock time
- block savings withdrawal while locked and show unlock timestamp
- send savings/loan operation confirmations separate from main menu

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896551ae8e88333b241719b534437c9