### PR TITLE
Use Decimal for savings and loan transactions

### DIFF
--- a/database/crud_transactions.py
+++ b/database/crud_transactions.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from _decimal import Decimal, ROUND_HALF_UP
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,14 +11,15 @@ async def create_transaction(
         session: AsyncSession,
         participant_id: int,
         tx_type: str,
-        amount: float,
+        amount: float | Decimal,
         status: str = "pending"
 ) -> Transaction:
     """Create a new transaction record with optional pending status."""
+    amt = Decimal(amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
     tx = Transaction(
         participant_id=participant_id,
         type=tx_type,
-        amount=amount,
+        amount=amt,
         status=status,
         created_at=datetime.now(timezone.utc)
     )

--- a/handlers/participant.py
+++ b/handlers/participant.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timezone, timedelta
+from _decimal import Decimal, ROUND_HALF_UP, InvalidOperation
 
 from aiogram import Router, F
 from aiogram.filters import Command, StateFilter
@@ -272,13 +273,21 @@ async def ask_to_savings(callback: CallbackQuery, state: FSMContext):
 @participant_router.message(StateFilter(CashOperations.waiting_for_savings_deposit_amount))
 async def process_to_savings(message: Message, state: FSMContext):
     text = message.text.strip()
-    if not text.isdigit() or int(text) <= 0:
+    try:
+        amount = Decimal(text)
+    except (InvalidOperation, ValueError):
         return await message.answer(
             LEXICON["invalid_amount"],
             parse_mode="HTML",
             reply_markup=cancel_operation_kb(),
         )
-    amount = int(text)
+    amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    if amount <= 0:
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
     data = await state.get_data()
     pid = data.get("participant_id")
     try:
@@ -314,13 +323,21 @@ async def ask_from_savings(callback: CallbackQuery, state: FSMContext):
 @participant_router.message(StateFilter(CashOperations.waiting_for_savings_withdraw_amount))
 async def process_from_savings(message: Message, state: FSMContext):
     text = message.text.strip()
-    if not text.isdigit() or int(text) <= 0:
+    try:
+        amount = Decimal(text)
+    except (InvalidOperation, ValueError):
         return await message.answer(
             LEXICON["invalid_amount"],
             parse_mode="HTML",
             reply_markup=cancel_operation_kb(),
         )
-    amount = int(text)
+    amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    if amount <= 0:
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
     data = await state.get_data()
     pid = data.get("participant_id")
     try:
@@ -359,13 +376,21 @@ async def ask_take_loan(callback: CallbackQuery, state: FSMContext):
 @participant_router.message(StateFilter(CashOperations.waiting_for_take_loan_amount))
 async def process_take_loan(message: Message, state: FSMContext):
     text = message.text.strip()
-    if not text.isdigit() or int(text) <= 0:
+    try:
+        amount = Decimal(text)
+    except (InvalidOperation, ValueError):
         return await message.answer(
             LEXICON["invalid_amount"],
             parse_mode="HTML",
             reply_markup=cancel_operation_kb(),
         )
-    amount = int(text)
+    amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    if amount <= 0:
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
     data = await state.get_data()
     pid = data.get("participant_id")
     try:
@@ -401,13 +426,21 @@ async def ask_repay_loan(callback: CallbackQuery, state: FSMContext):
 @participant_router.message(StateFilter(CashOperations.waiting_for_repay_loan_amount))
 async def process_repay_loan(message: Message, state: FSMContext):
     text = message.text.strip()
-    if not text.isdigit() or int(text) <= 0:
+    try:
+        amount = Decimal(text)
+    except (InvalidOperation, ValueError):
         return await message.answer(
             LEXICON["invalid_amount"],
             parse_mode="HTML",
             reply_markup=cancel_operation_kb(),
         )
-    amount = int(text)
+    amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    if amount <= 0:
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
     data = await state.get_data()
     pid = data.get("participant_id")
     try:


### PR DESCRIPTION
## Summary
- Handle savings and loan adjustments using `Decimal` values
- Parse decimal amounts in participant savings/loan handlers
- Quantize transaction amounts for savings/loan interest calculations

## Testing
- `pytest -q`
- `python -m py_compile database/crud_participant.py database/crud_transactions.py handlers/participant.py services/banking.py`


------
https://chatgpt.com/codex/tasks/task_e_689675a05d68833383bd9552c46895e4