### PR TITLE
feat: schedule weekly interest accrual

### DIFF
--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -168,6 +168,15 @@ LEXICON = {
     "deposit_declined": "❌ Your deposit request of {amount} 🪙 has been declined.\n"
                         "<code>{course_name}, {name}, tx_id: {tx_id}</code>",
 
+    # Interest accrual notifications
+    "interest_savings": "✅ {amount} 🪙 interest added to your savings in {course_name}.",
+    "interest_loan": "⚠️ {amount} 🪙 interest added to your loan in {course_name}.",
+    "interest_admin_stats": (
+        "Weekly interest applied for {course_name}:\n"
+        "Savings: {s_count} participants, total {s_total} 🪙\n"
+        "Loan: {l_count} participants, total {l_total} 🪙"
+    ),
+
     # region --- Withdraw and Deposit Flows ---
 
 }

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from handlers.common import common_router
 from handlers.registration import registration_router
 from handlers.participant import participant_router
 from keyboards.main_menu import get_main_menu_commands
+from services.scheduler import interest_scheduler
 
 logging.basicConfig(
     level=logging.INFO,
@@ -38,7 +39,10 @@ async def main() -> None:
         await conn.run_sync(Base.metadata.create_all)
     logger.info("Database tables created or already exist.")
 
-    # 5) Старт polling
+    # 5) Запуск периодического начисления процентов
+    asyncio.create_task(interest_scheduler(bot))
+
+    # 6) Старт polling
     await dp.start_polling(bot)
 
 

--- a/services/scheduler.py
+++ b/services/scheduler.py
@@ -1,0 +1,42 @@
+import asyncio
+from datetime import datetime, timedelta, time
+from sqlalchemy import select
+
+from aiogram import Bot
+
+from database.base import AsyncSessionLocal
+from database.models import Course, Participant, Transaction
+from services.banking import apply_weekly_interest
+
+
+async def interest_scheduler(bot: Bot, poll_interval: int = 60) -> None:
+    """Periodically apply weekly interest for courses on scheduled day/time."""
+    while True:
+        now = datetime.utcnow()
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(select(Course).where(Course.is_active))
+            courses = result.scalars().all()
+            for course in courses:
+                try:
+                    hour, minute = map(int, course.interest_time.split(":"))
+                except ValueError:
+                    # skip invalid time format
+                    continue
+                week_start = now.date() - timedelta(days=now.weekday())
+                interest_date = week_start + timedelta(days=course.interest_day)
+                scheduled_dt = datetime.combine(interest_date, time(hour, minute))
+                if now >= scheduled_dt:
+                    stmt = (
+                        select(Transaction.id)
+                        .join(Participant)
+                        .where(
+                            Participant.course_id == course.id,
+                            Transaction.type.in_(["savings_interest", "loan_interest"]),
+                            Transaction.created_at >= scheduled_dt,
+                        )
+                        .limit(1)
+                    )
+                    existing = await session.execute(stmt)
+                    if existing.scalar_one_or_none() is None:
+                        await apply_weekly_interest(course.id, bot)
+        await asyncio.sleep(poll_interval)


### PR DESCRIPTION
## Summary
- add scheduler to apply weekly interest at configured day and time
- notify each participant and send admins weekly interest statistics
- launch the scheduler on bot startup
- include course name in participant and admin interest notifications

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68973ac68d5c8333968fbb3f165aaee0