### PR TITLE
Block start and register during active operations

### DIFF
--- a/handlers/participant.py
+++ b/handlers/participant.py
@@ -37,7 +37,7 @@ participant_router.message.filter(RoleFilter("participant"))
 participant_router.callback_query.filter(RoleFilter("participant"))
 
 
-@participant_router.message(Command("start"))
+@participant_router.message(Command("start"), StateFilter(None))
 async def participant_main(message: Message, state: FSMContext):
     """Entry point for participant. Select course if needed."""
     await state.clear()
@@ -75,6 +75,12 @@ async def participant_main(message: Message, state: FSMContext):
             LEXICON["choose_course_prompt"],
             reply_markup=select_course_kb(courses),
         )
+
+
+@participant_router.message(Command("start"), ~StateFilter(None))
+async def participant_busy(message: Message):
+    """Warn participant to finish current operation before using /start."""
+    await message.answer(LEXICON["operation_in_progress"], parse_mode="HTML")
 
 
 @participant_router.callback_query(F.data.startswith("participant:choose_course:"))

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -12,18 +12,30 @@ from states.fsm import Registration
 registration_router = Router()
 
 
-@registration_router.message(Command("start"), RoleFilter("guest"))
+@registration_router.message(Command("start"), RoleFilter("guest"), StateFilter(None))
 async def cmd_start(message: Message, state: FSMContext):
     """Start registration for guests via /start."""
     await message.answer(LEXICON["registration_code_request"], parse_mode="HTML")
     await state.set_state(Registration.waiting_for_code)
 
 
-@registration_router.message(Command("register"), RoleFilter("participant"))
+@registration_router.message(Command("register"), RoleFilter("participant"), StateFilter(None))
 async def cmd_register(message: Message, state: FSMContext):
     """Allow existing participants to re-register using /register."""
     await message.answer(LEXICON["registration_code_request"], parse_mode="HTML")
     await state.set_state(Registration.waiting_for_code)
+
+
+@registration_router.message(Command("start"), RoleFilter("guest"), ~StateFilter(None))
+async def start_busy(message: Message):
+    """Warn guest to complete current operation before restarting registration."""
+    await message.answer(LEXICON["operation_in_progress"], parse_mode="HTML")
+
+
+@registration_router.message(Command("register"), RoleFilter("participant"), ~StateFilter(None))
+async def register_busy(message: Message):
+    """Warn participant to complete current operation before re-registering."""
+    await message.answer(LEXICON["operation_in_progress"], parse_mode="HTML")
 
 
 @registration_router.message(StateFilter(Registration.waiting_for_code))

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -48,6 +48,8 @@ LEXICON = {
     "registration_success": "✅ You have been registered as {name}! Welcome.\n\n"
                             "Now you can use /start to access your banking menu.",  # Success
 
+    "operation_in_progress": "⚠️ Please finish the current operation before starting another one.",
+
     # endregion --- Participant Registration ---
 
     # region --- Admin Panel ---


### PR DESCRIPTION
## Summary
- prevent /start and /register from running when a user is mid-registration or transaction
- send a warning asking the user to finish the current operation
- add shared lexicon entry for the new warning message

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689761b1158483339723a8db3f00bdbe