### PR TITLE
Notify admin on participant cash request cancellations

### DIFF
--- a/handlers/participant.py
+++ b/handlers/participant.py
@@ -482,8 +482,19 @@ async def user_cancel_cash_request(callback: CallbackQuery, state: FSMContext):
     pid = data.get("participant_id")
     participant_name = data.get("participant_name")
     course_name = data.get("course_name")
+    course_id = data.get("course_id")
     if tx_id and pid:
         await cancel_transaction(pid, tx_id)
+        if course_id:
+            await send_message_to_course_creator(
+                bot=callback.bot,
+                course_id=course_id,
+                text=LEXICON["admin_tx_cancelled_admin"].format(
+                    course_name=course_name,
+                    name=participant_name,
+                    tx_id=tx_id,
+                ),
+            )
 
     await state.set_state(None)
     await state.set_data(data)

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -159,6 +159,7 @@ LEXICON = {
     # Admin UI messages after handling
     "admin_tx_approved_admin": "✅ Transaction approved.\n<code>{course_name}, {name}, tx_id: {tx_id}</code>",
     "admin_tx_declined_admin": "❌ Transaction declined.\n<code>{course_name}, {name}, tx_id: {tx_id}</code>",
+    "admin_tx_cancelled_admin": "🚫 Transaction canceled by participant.\n<code>{course_name}, {name}, tx_id: {tx_id}</code>",
 
     # Participant notifications on approval/decline
     "withdraw_approved": "✅ Your withdrawal of {amount} 🪙 has been approved.\n"


### PR DESCRIPTION
## Summary
- Alert course creator when a participant cancels a pending withdraw/deposit request
- Add lexicon entry for admin cancellation notification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689764d8bf2c83338d9c2baf74628332