### PR TITLE
feat: allow admins to edit course details

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,6 +1,7 @@
 # handlers/admin.py
 
 import logging
+from datetime import datetime
 
 from aiogram import Router, F
 from aiogram.filters import Command, StateFilter
@@ -15,7 +16,12 @@ from aiogram.types import (
 from database.base import AsyncSessionLocal
 from database.crud_transactions import update_transaction_status
 from database.crud_participant import adjust_participant_balance
-from database.crud_courses import finish_course, get_course_stats, get_current_rate
+from database.crud_courses import (
+    finish_course,
+    get_course_stats,
+    get_current_rate,
+    set_rate,
+)
 from database.models import Course, Transaction, Participant
 from filters.role_filter import RoleFilter
 from keyboards.admin import course_actions_kb
@@ -31,7 +37,7 @@ from services.course_creation_flow import (
 )
 from services.participant_menu import build_participant_menu
 from services.presenters import render_course_info
-from states.fsm import CourseCreation
+from states.fsm import CourseCreation, CourseEdit
 
 logger = logging.getLogger(__name__)
 admin_router = Router()
@@ -87,6 +93,190 @@ async def admin_course_finish(callback: CallbackQuery):
     # после завершения возвращаем главное меню одним edit
     text, kb = await build_admin_menu(callback.from_user.id)
     await callback.message.edit_text(text, parse_mode="HTML", reply_markup=kb)
+ 
+
+# region --- Editing course parameters ---
+
+
+async def _send_course_info(message: Message, course_id: int) -> None:
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        stats = await get_course_stats(session, course.id)
+        savings_rate = await get_current_rate(session, course.id, "savings")
+        loan_rate = await get_current_rate(session, course.id, "loan")
+
+    text = render_course_info(course, stats, savings_rate, loan_rate)
+    if course.is_active:
+        kb = course_actions_kb(course.id)
+    else:
+        kb = InlineKeyboardMarkup(inline_keyboard=[[InlineKeyboardButton(
+            text=LEXICON["button_back"], callback_data="admin:back_to_main")]])
+
+    await message.answer(text, reply_markup=kb)
+
+
+@admin_router.callback_query(F.data.startswith("admin:course:edit:"))
+async def admin_course_edit_start(callback: CallbackQuery, state: FSMContext):
+    await callback.answer()
+    _, _, _, field, course_id = callback.data.split(":", 4)
+    prompts = {
+        "name": "course_name_request",
+        "description": "course_description_request",
+        "interest_day": "course_interest_day_request",
+        "interest_time": "course_interest_time_request",
+        "savings_rate": "course_savings_rate_request",
+        "loan_rate": "course_loan_rate_request",
+        "max_loan": "course_max_loan_request",
+        "savings_lock": "course_savings_lock_request",
+    }
+    states_map = {
+        "name": CourseEdit.waiting_for_name,
+        "description": CourseEdit.waiting_for_description,
+        "interest_day": CourseEdit.waiting_for_interest_day,
+        "interest_time": CourseEdit.waiting_for_interest_time,
+        "savings_rate": CourseEdit.waiting_for_savings_rate,
+        "loan_rate": CourseEdit.waiting_for_loan_rate,
+        "max_loan": CourseEdit.waiting_for_max_loan,
+        "savings_lock": CourseEdit.waiting_for_savings_lock,
+    }
+    if field not in prompts:
+        return
+    await state.update_data(course_id=int(course_id))
+    await callback.message.answer(LEXICON[prompts[field]], parse_mode="HTML")
+    await state.set_state(states_map[field])
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_name))
+async def edit_course_name(message: Message, state: FSMContext):
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        course.name = message.text.strip()
+        await session.commit()
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_description))
+async def edit_course_description(message: Message, state: FSMContext):
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        course.description = message.text.strip()
+        await session.commit()
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_interest_day))
+async def edit_course_interest_day(message: Message, state: FSMContext):
+    text = message.text.strip()
+    if not text.isdigit():
+        await message.answer(LEXICON["course_value_invalid"], parse_mode="HTML")
+        return
+    day = int(text)
+    if day < 0 or day > 6:
+        await message.answer(LEXICON["course_value_invalid"], parse_mode="HTML")
+        return
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        course.interest_day = day
+        await session.commit()
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_interest_time))
+async def edit_course_interest_time(message: Message, state: FSMContext):
+    text = message.text.strip()
+    try:
+        datetime.strptime(text, "%H:%M")
+    except ValueError:
+        await message.answer(LEXICON["course_value_invalid"], parse_mode="HTML")
+        return
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        course.interest_time = text
+        await session.commit()
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_savings_rate))
+async def edit_course_savings_rate(message: Message, state: FSMContext):
+    text = message.text.replace(",", ".").strip()
+    try:
+        rate = float(text)
+    except ValueError:
+        await message.answer(LEXICON["course_rate_invalid"], parse_mode="HTML")
+        return
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        await set_rate(session, course_id, "savings", rate)
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_loan_rate))
+async def edit_course_loan_rate(message: Message, state: FSMContext):
+    text = message.text.replace(",", ".").strip()
+    try:
+        rate = float(text)
+    except ValueError:
+        await message.answer(LEXICON["course_rate_invalid"], parse_mode="HTML")
+        return
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        await set_rate(session, course_id, "loan", rate)
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_max_loan))
+async def edit_course_max_loan(message: Message, state: FSMContext):
+    text = message.text.replace(",", ".").strip()
+    try:
+        amount = float(text)
+    except ValueError:
+        await message.answer(LEXICON["course_value_invalid"], parse_mode="HTML")
+        return
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        course.max_loan_amount = amount
+        await session.commit()
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+@admin_router.message(StateFilter(CourseEdit.waiting_for_savings_lock))
+async def edit_course_savings_lock(message: Message, state: FSMContext):
+    text = message.text.strip()
+    try:
+        days = int(text)
+    except ValueError:
+        await message.answer(LEXICON["course_value_invalid"], parse_mode="HTML")
+        return
+    data = await state.get_data()
+    course_id = data["course_id"]
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        course.savings_withdrawal_delay = days
+        await session.commit()
+    await state.clear()
+    await _send_course_info(message, course_id)
+
+
+# endregion --- Editing course parameters ---
 
 
 # region --- FSM для /new_course ---
@@ -177,13 +367,12 @@ async def admin_tx_approve(callback: CallbackQuery):
 
     # Mark the admin’s notification as handled
     await callback.message.edit_text(
-        f"{callback.message.text}\n\n"
-        f"{LEXICON['admin_tx_approved_admin'].format(
-            tx_id=tx_id,
-            course_name=course_name,
-            name=participant.name)}",
+        (
+            f"{callback.message.text}\n\n"
+            f"{LEXICON['admin_tx_approved_admin'].format(tx_id=tx_id, course_name=course_name, name=participant.name)}"
+        ),
         parse_mode="HTML",
-        reply_markup=None
+        reply_markup=None,
     )
 
 
@@ -227,13 +416,13 @@ async def admin_tx_decline(callback: CallbackQuery):
 
     # Mark the admin’s notification as handled
     await callback.message.edit_text(
-        f"{callback.message.text}\n\n"
-        f"{LEXICON['admin_tx_approved_admin'].format(
-            tx_id=tx_id,
-            course_name=course_name,
-            name=participant.name)}",
+        (
+            f"{callback.message.text}\n\n"
+            f"{LEXICON['admin_tx_approved_admin'].format(tx_id=tx_id, course_name=course_name, name=participant.name)}"
+        ),
         parse_mode="HTML",
-        reply_markup=None
+        reply_markup=None,
     )
 
 # endregion --- Approving/Declining Withdrawal/Deposit Requests ---
+

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -40,19 +40,59 @@ def courses_list_kb(courses: list[Course]) -> InlineKeyboardMarkup:
 
 
 def course_actions_kb(course_id: int) -> InlineKeyboardMarkup:
-    """
-    Под карточкой курса: «Завершить курс» + «Назад»
-    """
-    return InlineKeyboardMarkup(inline_keyboard=[[
-        InlineKeyboardButton(
-            text=LEXICON["button_finish_course"],
-            callback_data=f"admin:course:finish:{course_id}"
-        ),
-        InlineKeyboardButton(
-            text=LEXICON["button_back"],
-            callback_data="admin:back_to_main"
-        ),
-    ]])
+    """Keyboard under course info allowing full management."""
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_name"],
+                callback_data=f"admin:course:edit:name:{course_id}"
+            ),
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_description"],
+                callback_data=f"admin:course:edit:description:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_interest_day"],
+                callback_data=f"admin:course:edit:interest_day:{course_id}"
+            ),
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_interest_time"],
+                callback_data=f"admin:course:edit:interest_time:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_savings_rate"],
+                callback_data=f"admin:course:edit:savings_rate:{course_id}"
+            ),
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_loan_rate"],
+                callback_data=f"admin:course:edit:loan_rate:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_max_loan"],
+                callback_data=f"admin:course:edit:max_loan:{course_id}"
+            ),
+            InlineKeyboardButton(
+                text=LEXICON["button_edit_savings_lock"],
+                callback_data=f"admin:course:edit:savings_lock:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
+                text=LEXICON["button_finish_course"],
+                callback_data=f"admin:course:finish:{course_id}"
+            ),
+            InlineKeyboardButton(
+                text=LEXICON["button_back"],
+                callback_data="admin:back_to_main"
+            ),
+        ],
+    ])
 
 def tx_approval_kb(tx_id: int) -> InlineKeyboardMarkup:
     """

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -16,6 +16,11 @@ LEXICON = {
     "course_savings_rate_request": "Enter weekly savings interest rate (%)",
     "course_loan_rate_request": "Enter weekly loan interest rate (%)",
     "course_rate_invalid": "Please enter a valid percentage.",
+    "course_max_loan_request": "Enter maximum loan amount:",
+    "course_savings_lock_request": "Enter savings lock period (days):",
+    "course_interest_day_request": "Enter interest payout weekday (0=Monday ... 6=Sunday):",
+    "course_interest_time_request": "Enter interest payout time (HH:MM, UTC):",
+    "course_value_invalid": "Please enter a valid number.",
     "course_sheet_request": "Please send the Google Sheets link containing the list of participants:",
     # Ask for sheet URL
 
@@ -68,6 +73,14 @@ LEXICON = {
     "button_info": "ℹ️ About Bot",  # Show bot info
     "button_finish_course": "🛑 Finish Course",  # End a course
     "button_back": "↩️ Back",  # Navigate back
+    "button_edit_name": "✏️ Title",
+    "button_edit_description": "✏️ Description",
+    "button_edit_interest_day": "📅 Interest day",
+    "button_edit_interest_time": "⏰ Interest time",
+    "button_edit_savings_rate": "💹 Savings rate",
+    "button_edit_loan_rate": "💸 Loan rate",
+    "button_edit_max_loan": "💳 Max loan",
+    "button_edit_savings_lock": "⏳ Savings lock",
 
     # Emojis indicating course status
     "emoji_active": "🟢",  # Active course
@@ -82,7 +95,8 @@ LEXICON = {
         "💹% Savings rate: {savings_rate}%\n"
         "💸% Loan rate: {loan_rate}%\n"
         "💳⬆️ Max loan: {max_loan}\n"
-        "💹⏳ Savings lock: {savings_delay} days\n\n"
+        "💹⏳ Savings lock: {savings_delay} days\n"
+        "📆 Interest payout: {interest_day} {interest_time} UTC\n\n"
         "👥 Total participants: {total}\n"
         "📝 Registered: {registered}\n"
         "💳 Average balance: {avg_balance:.2f}"

--- a/services/presenters.py
+++ b/services/presenters.py
@@ -1,3 +1,5 @@
+from calendar import day_name
+
 from lexicon.lexicon_en import LEXICON
 
 
@@ -36,4 +38,6 @@ def render_course_info(course, stats: dict, savings_rate: float, loan_rate: floa
         loan_rate=loan_rate,
         max_loan=course.max_loan_amount,
         savings_delay=course.savings_withdrawal_delay,
+        interest_day=day_name[course.interest_day],
+        interest_time=course.interest_time,
     )

--- a/states/fsm.py
+++ b/states/fsm.py
@@ -1,5 +1,6 @@
 from aiogram.fsm.state import StatesGroup, State
 
+
 class CourseCreation(StatesGroup):
     waiting_for_name = State()
     waiting_for_description = State()
@@ -7,11 +8,25 @@ class CourseCreation(StatesGroup):
     waiting_for_loan_rate = State()
     waiting_for_sheet = State()
 
+
+class CourseEdit(StatesGroup):
+    waiting_for_name = State()
+    waiting_for_description = State()
+    waiting_for_interest_day = State()
+    waiting_for_interest_time = State()
+    waiting_for_savings_rate = State()
+    waiting_for_loan_rate = State()
+    waiting_for_max_loan = State()
+    waiting_for_savings_lock = State()
+
+
 class Registration(StatesGroup):
     waiting_for_code = State()
 
+
 class CourseFinish(StatesGroup):
     waiting_for_course = State()
+
 
 class CashOperations(StatesGroup):
     waiting_for_withdraw_amount = State()
@@ -21,3 +36,4 @@ class CashOperations(StatesGroup):
     waiting_for_take_loan_amount = State()
     waiting_for_repay_loan_amount = State()
     waiting_for_approval = State()
+


### PR DESCRIPTION
## Summary
- show interest payout day and time in course info
- let admins change course parameters from a new action keyboard
- add FSM states and handlers to update course fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897888765988333a99f03a9339f7a61