### PR TITLE
Add course finish confirmation and participant final balance notice

### DIFF
--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -39,7 +39,9 @@ LEXICON = {
     # Finish Course Flow
     "finish_no_active": "You have no active courses to finish.",
     "finish_select": "Select the course you want to finish:",
+    "finish_confirm": "⚠️ Course “{name}” will be permanently closed. Finish the course?",
     "finish_success": "✅ Course “{name}” has been successfully finished.",
+    "finish_participant_notify": "Course <b>{name}</b> has been finished, your final balance:",
 
     # endregion --- Course Management ---
 


### PR DESCRIPTION
## Summary
- require admin confirmation with course name before finishing a course
- notify each participant when a course ends and show their final balance without keyboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689872f7e1788333b73cabf1a2a9ccf7