### PR TITLE
feat: sync participant balances to Google Sheets

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -39,6 +39,7 @@ from services.participant_menu import build_participant_menu
 from services.presenters import render_course_info
 from states.fsm import CourseCreation, CourseEdit
 from sqlalchemy import select
+from services.google_sheets import update_participant_finances
 
 logger = logging.getLogger(__name__)
 admin_router = Router()
@@ -402,6 +403,8 @@ async def admin_tx_approve(callback: CallbackQuery):
             await adjust_participant_balance(session, participant, tx.amount)
         elif tx.type == "cash_withdrawal":
             await adjust_participant_balance(session, participant, -tx.amount)
+
+    await update_participant_finances(participant.id)
 
     # Notify the participant
     if tx.type == "cash_deposit":

--- a/services/google_sheets.py
+++ b/services/google_sheets.py
@@ -1,9 +1,16 @@
 # services/google_sheets.py
 
 import re
+from datetime import datetime
+
 import gspread
+from gspread.utils import rowcol_to_a1
 from oauth2client.service_account import ServiceAccountCredentials
+from sqlalchemy import select
+
 from config_data import config
+from database.base import AsyncSessionLocal
+from database.models import Course, Participant, Transaction
 
 # Авторизация
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
@@ -57,4 +64,63 @@ def mark_registered(sheet_url: str, email: str) -> None:
         if row.get("Email", "").strip().lower() == email.lower():
             sheet.update_cell(idx, 4, "TRUE")
             break
+
+
+async def update_participant_finances(participant_id: int) -> None:
+    """Обновляет данные баланса участника в Google Sheet."""
+    async with AsyncSessionLocal() as session:
+        participant = await session.get(Participant, participant_id)
+        if not participant:
+            return
+
+        course = await session.get(Course, participant.course_id)
+        if not course or not course.sheet_url:
+            return
+
+        ss_id = _normalize_url(course.sheet_url)
+        sheet = _gs_client.open_by_key(ss_id).sheet1
+
+        records = sheet.get_all_records()
+        row_idx = None
+        for idx, row in enumerate(records, start=2):
+            if row.get("Email", "").strip().lower() == participant.email.lower():
+                row_idx = idx
+                break
+        if row_idx is None:
+            return
+
+        total = participant.balance + participant.savings_balance - participant.loan_balance
+        sheet.update_cell(row_idx, 5, float(total))
+        sheet.update_cell(row_idx, 6, float(participant.balance))
+        sheet.update_cell(row_idx, 7, float(participant.savings_balance))
+        sheet.update_cell(row_idx, 8, float(participant.loan_balance))
+
+        # Clear previous operations
+        if sheet.col_count >= 9:
+            start_a1 = rowcol_to_a1(row_idx, 9)
+            end_a1 = rowcol_to_a1(row_idx, sheet.col_count)
+            sheet.batch_clear([f"{start_a1}:{end_a1}"])
+
+        # Fetch cash operations
+        result = await session.execute(
+            select(Transaction)
+            .where(Transaction.participant_id == participant_id)
+            .where(Transaction.type.in_(["cash_deposit", "cash_withdrawal"]))
+            .where(Transaction.status == "completed")
+            .order_by(Transaction.created_at)
+        )
+        operations = result.scalars().all()
+
+        col = 9
+        for tx in operations:
+            date_str = tx.created_at.strftime("%d.%m")
+            if tx.type == "cash_withdrawal":
+                text = f"{date_str} -{tx.amount}"
+                color = {"red": 1, "green": 0, "blue": 0}
+            else:
+                text = f"{date_str} {tx.amount}"
+                color = {"red": 0, "green": 1, "blue": 0}
+            sheet.update_cell(row_idx, col, text)
+            sheet.format(rowcol_to_a1(row_idx, col), {"textFormat": {"foregroundColor": color}})
+            col += 1
 


### PR DESCRIPTION
## Summary
- add Google Sheets finance updater with balance and transaction columns
- update sheets after admin approvals and balance-changing operations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899a0efbabc8333aedf5083b6291a52