### PR TITLE
feat: update course spreadsheet

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -37,6 +37,7 @@ from services.course_creation_flow import (
 )
 from services.participant_menu import build_participant_menu
 from services.presenters import render_course_info
+from services.google_sheets import update_course_balances
 from states.fsm import CourseCreation, CourseEdit
 from sqlalchemy import select
 
@@ -81,6 +82,13 @@ async def admin_back(callback: CallbackQuery):
     await callback.answer()
     text, kb = await build_admin_menu(callback.from_user.id)
     await callback.message.edit_text(text, parse_mode="HTML", reply_markup=kb)
+
+
+@admin_router.callback_query(F.data.startswith("admin:course:update_sheet:"))
+async def admin_course_update_sheet(callback: CallbackQuery):
+    _, _, _, _, course_id = callback.data.split(":", 4)
+    await update_course_balances(int(course_id))
+    await callback.answer(LEXICON["sheet_updated"])
 
 
 @admin_router.callback_query(

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -84,6 +84,12 @@ def course_actions_kb(course_id: int) -> InlineKeyboardMarkup:
         ],
         [
             InlineKeyboardButton(
+                text=LEXICON["button_update_sheet"],
+                callback_data=f"admin:course:update_sheet:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
                 text=LEXICON["button_finish_course"],
                 callback_data=f"admin:course:finish:{course_id}"
             ),

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -83,6 +83,7 @@ LEXICON = {
     "button_edit_loan_rate": "💸 Loan rate",
     "button_edit_max_loan": "⬆️ Max loan",
     "button_edit_savings_lock": "⏳ Savings lock",
+    "button_update_sheet": "🔄 Update Spreadsheet",
 
     # Emojis indicating course status
     "emoji_active": "🟢",  # Active course
@@ -93,7 +94,8 @@ LEXICON = {
         "📖 Title: {name}\n"
         "📝 Description: {description}\n"
         "🗓 Created: {created_at:%d.%m.%Y}\n"
-        "{course_status_emoji} Status: {status}\n\n"
+        "{course_status_emoji} Status: {status}\n"
+        "📄 Spreadsheet: {sheet_url}\n\n"
         "💹 Savings rate: {savings_rate}%\n"
         "💸 Loan rate: {loan_rate}%\n"
         "⬆️ Max loan: {max_loan}\n"
@@ -107,6 +109,8 @@ LEXICON = {
     # Status Values
     "status_active": "active",  # Course is ongoing
     "status_finished": "finished",  # Course has ended
+
+    "sheet_updated": "✅ Spreadsheet updated.",
 
     # endregion --- Admin Panel ---
 

--- a/services/presenters.py
+++ b/services/presenters.py
@@ -31,6 +31,7 @@ def render_course_info(course, stats: dict, savings_rate: float, loan_rate: floa
         created_at=course.created_at,
         course_status_emoji=course_status_emoji,
         status=status,
+        sheet_url=course.sheet_url or "-",
         total=stats["total"],
         registered=stats["registered"],
         avg_balance=stats["avg_balance"],


### PR DESCRIPTION
## Summary
- update Google Sheets with participant balances
- show spreadsheet link in course info
- add admin action to trigger sheet sync

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b937cbac8333ab20a6d93dcafba0