### PR TITLE
refactor: modularize bot setup

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core application setup modules."""

--- a/core/bot.py
+++ b/core/bot.py
@@ -1,0 +1,26 @@
+import logging
+from aiogram import Bot, Dispatcher
+from config_data import config
+from handlers import register_handlers
+from keyboards.main_menu import get_main_menu_commands
+
+logger = logging.getLogger(__name__)
+
+
+def create_bot() -> Bot:
+    """Create and return a Bot instance using configuration."""
+    return Bot(token=config.tg_bot.token)
+
+
+def create_dispatcher() -> Dispatcher:
+    """Create dispatcher and register all handlers."""
+    dp = Dispatcher()
+    register_handlers(dp)
+    return dp
+
+
+async def setup_main_menu(bot: Bot) -> None:
+    """Install global bot commands menu."""
+    commands = get_main_menu_commands()
+    await bot.set_my_commands(commands)
+    logger.info("Main menu commands set: %s", commands)

--- a/core/db.py
+++ b/core/db.py
@@ -1,0 +1,7 @@
+from database.base import engine, Base
+
+
+async def init_db() -> None:
+    """Create database tables if they do not exist."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,0 +1,15 @@
+"""Message handlers registration."""
+from aiogram import Dispatcher
+
+from .admin import admin_router
+from .common import common_router
+from .participant import participant_router
+from .registration import registration_router
+
+
+def register_handlers(dp: Dispatcher) -> None:
+    """Include all routers into the dispatcher."""
+    dp.include_router(common_router)
+    dp.include_router(admin_router)
+    dp.include_router(participant_router)
+    dp.include_router(registration_router)

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Business logic modules for the bot."""


### PR DESCRIPTION
## Summary
- centralize bot creation, dispatcher setup, and command registration in `core.bot`
- add `core.db` to initialize database tables
- collect routers in `handlers.register_handlers` and simplify `main`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899d814d7ec8333aac2f7015a62353f