### PR TITLE
Extract participant info rendering

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -36,7 +36,7 @@ from services.course_creation_flow import (
     process_course_sheet,
 )
 from services.participant_menu import build_participant_menu
-from services.presenters import render_course_info
+from services.presenters import render_course_info, render_participant_info
 from services.google_sheets import update_course_balances
 from states.fsm import CourseCreation, CourseEdit
 from sqlalchemy import select
@@ -142,14 +142,14 @@ async def admin_course_finish_confirm(callback: CallbackQuery):
             LEXICON["finish_participant_notify"].format(name=course.name),
             parse_mode="HTML",
         )
-        balance_text = LEXICON["main_balance_text"].format(
-            name=participant.name,
-            course_name=course.name,
-            balance=participant.balance,
-            savings=participant.savings_balance,
-            loan=participant.loan_balance,
-            savings_rate=savings_rate,
-            loan_rate=loan_rate,
+        balance_text = render_participant_info(
+            participant.name,
+            course.name,
+            participant.balance,
+            participant.savings_balance,
+            participant.loan_balance,
+            savings_rate,
+            loan_rate,
         )
         await callback.bot.send_message(
             participant.telegram_id,

--- a/services/participant_menu.py
+++ b/services/participant_menu.py
@@ -6,7 +6,7 @@ from database.crud_courses import get_current_rate
 
 from keyboards.participant import main_menu_participant_kb
 
-from lexicon.lexicon_en import LEXICON
+from services.presenters import render_participant_info
 
 
 async def build_participant_menu(
@@ -27,14 +27,14 @@ async def build_participant_menu(
         savings_rate = await get_current_rate(session, participant.course_id, "savings")
         loan_rate = await get_current_rate(session, participant.course_id, "loan")
 
-    text = LEXICON["main_balance_text"].format(
-        name=participant_name,
-        course_name=course_name,
-        balance=balance,
-        savings=savings,
-        loan=loan,
-        savings_rate=savings_rate,
-        loan_rate=loan_rate
+    text = render_participant_info(
+        participant_name,
+        course_name,
+        balance,
+        savings,
+        loan,
+        savings_rate,
+        loan_rate,
     )
     kb = main_menu_participant_kb()
     return text, kb

--- a/services/presenters.py
+++ b/services/presenters.py
@@ -42,3 +42,24 @@ def render_course_info(course, stats: dict, savings_rate: float, loan_rate: floa
         interest_day=day_name[course.interest_day],
         interest_time=course.interest_time,
     )
+
+
+def render_participant_info(
+    name: str,
+    course_name: str,
+    balance,
+    savings,
+    loan,
+    savings_rate: float,
+    loan_rate: float,
+) -> str:
+    """Собирает текст с балансом участника."""
+    return LEXICON["main_balance_text"].format(
+        name=name,
+        course_name=course_name,
+        balance=balance,
+        savings=savings,
+        loan=loan,
+        savings_rate=savings_rate,
+        loan_rate=loan_rate,
+    )


### PR DESCRIPTION
## Summary
- move participant balance message formatting into `render_participant_info` in presenters
- reuse `render_participant_info` in participant menu and admin handlers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899d8adf44c83338bbb6bfe6a3dce1d