### PR TITLE
Refactor admin menu construction for clearer separation

### DIFF
--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -39,6 +39,13 @@ def courses_list_kb(courses: list[Course]) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
+def admin_menu_kb(courses: list[Course]) -> InlineKeyboardMarkup:
+    """Keyboard for the admin main menu with a course list and action row."""
+    rows = courses_list_kb(courses).inline_keyboard if courses else []
+    rows += main_menu_admin_kb().inline_keyboard
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
 def course_actions_kb(course_id: int) -> InlineKeyboardMarkup:
     """Keyboard under course info allowing full management."""
     return InlineKeyboardMarkup(inline_keyboard=[

--- a/services/admin_menu.py
+++ b/services/admin_menu.py
@@ -1,42 +1,21 @@
 # services/admin_menu.py
 
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.types import InlineKeyboardMarkup
 
 from database.base import AsyncSessionLocal
 from database.crud_courses import get_all_courses_by_admin
-from keyboards.admin import main_menu_admin_kb
-from lexicon.lexicon_en import LEXICON
+from keyboards.admin import admin_menu_kb
+from services.presenters import render_admin_menu
 
 
 async def build_admin_menu(user_id: int) -> tuple[str, InlineKeyboardMarkup]:
+    """Builds text and keyboard for the admin main menu."""
     async with AsyncSessionLocal() as session:
-        all_courses = await get_all_courses_by_admin(session, user_id)
+        courses = await get_all_courses_by_admin(session, user_id)
 
-    if not all_courses:
-        text = LEXICON["admin_main_no_courses"]
-        kb = main_menu_admin_kb()
-        return text, kb
+    active = sorted((c for c in courses if c.is_active), key=lambda c: c.name.lower())
+    finished = sorted((c for c in courses if not c.is_active), key=lambda c: c.name.lower())
 
-    active = sorted([c for c in all_courses if c.is_active],
-                    key=lambda c: c.name.lower())
-    finished = sorted([c for c in all_courses if not c.is_active],
-                      key=lambda c: c.name.lower())
-
-    text = LEXICON["admin_main_has_courses"].format(
-        active=len(active), finished=len(finished)
-    )
-
-    rows = [
-               [InlineKeyboardButton(
-                   text=f"{LEXICON['emoji_active']} {c.name}",
-                   callback_data=f"admin:course:info:{c.id}"
-               )] for c in active
-           ] + [
-               [InlineKeyboardButton(
-                   text=f"{LEXICON['emoji_finished']} {c.name}",
-                   callback_data=f"admin:course:info:{c.id}"
-               )] for c in finished
-           ]
-    rows += main_menu_admin_kb().inline_keyboard
-    kb = InlineKeyboardMarkup(inline_keyboard=rows)
+    text = render_admin_menu(len(active), len(finished))
+    kb = admin_menu_kb(active + finished)
     return text, kb

--- a/services/presenters.py
+++ b/services/presenters.py
@@ -1,5 +1,4 @@
 from calendar import day_name
-
 from lexicon.lexicon_en import LEXICON
 
 
@@ -63,3 +62,10 @@ def render_participant_info(
         savings_rate=savings_rate,
         loan_rate=loan_rate,
     )
+
+
+def render_admin_menu(active: int, finished: int) -> str:
+    """Generate text for the admin main menu based on course counts."""
+    if active + finished == 0:
+        return LEXICON["admin_main_no_courses"]
+    return LEXICON["admin_main_has_courses"].format(active=active, finished=finished)


### PR DESCRIPTION
## Summary
- add reusable `admin_menu_kb` keyboard builder
- move admin menu text generation to presenters
- simplify admin menu service to orchestrate data and UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_689a30f2c4cc83339b3ff3ccd6346022