### PR TITLE
feat: automate course sheet management

### DIFF
--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -87,6 +87,16 @@ def course_actions_kb(course_id: int) -> InlineKeyboardMarkup:
         ],
         [
             InlineKeyboardButton(
+                text=LEXICON["button_generate_regcodes"],
+                callback_data=f"admin:course:gen_codes:{course_id}"
+            ),
+            InlineKeyboardButton(
+                text=LEXICON["button_transfer_ownership"],
+                callback_data=f"admin:course:transfer:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
                 text=LEXICON["button_update_sheet"],
                 callback_data=f"admin:course:update_sheet:{course_id}"
             ),

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -21,20 +21,20 @@ LEXICON = {
     "course_interest_day_request": "Enter interest payout weekday (0=Monday ... 6=Sunday):",
     "course_interest_time_request": "Enter interest payout time (HH:MM, UTC):",
     "course_value_invalid": "Please enter a valid number.",
-    "course_sheet_request": "Please send the Google Sheets link containing the list of participants:",
-    # Ask for sheet URL
+    "course_sheet_created": (
+        "✅ Course “{name}” created.\n"
+        "Spreadsheet: {url}\n"
+        "Add participants to this table, then press \"Generate RegCodes\" in the course card."
+    ),
+    "sheet_creation_failed": "❌ Failed to create spreadsheet. Please try again later.",
+    "sheet_read_failed": "❌ Failed to read spreadsheet.",
 
-    # Errors related to Google Sheets
-    "course_sheet_invalid": "❌ Failed to read data from Google Sheets. Please check the link and try again.",
-    "course_sheet_invalid_format": "❗️ It seems this is not a Google Sheets link. Please send a valid link.",
-    "course_sheet_unreachable": "❌ Could not access the sheet. Make sure you have granted access to the service "
-                                "account.",
-    "course_sheet_empty": "⚠️ The sheet is empty or doesn't contain the columns 'Name' and 'Email'. Please check its "
-                          "contents.",
+    # Messages for registration code generation
+    "regcodes_generated": "✅ {count} registration codes generated.",
+    "regcodes_no_new": "No new participants found.",
 
-    # Confirmation once a course is created
-    "course_created": "✅ Course “{name}” created, {count} participants added. Registration codes have been written to "
-                      "the Google Sheets.",
+    # Warning used in protected sheet ranges
+    "sheet_protect_warning": "Do not edit this unless you are absolutely sure what you are doing.",
 
     # Finish Course Flow
     "finish_no_active": "You have no active courses to finish.",
@@ -84,6 +84,8 @@ LEXICON = {
     "button_edit_max_loan": "⬆️ Max loan",
     "button_edit_savings_lock": "⏳ Savings lock",
     "button_update_sheet": "🔄 Update Spreadsheet",
+    "button_generate_regcodes": "🔑 Generate RegCodes",
+    "button_transfer_ownership": "👤 Transfer Ownership",
 
     # Emojis indicating course status
     "emoji_active": "🟢",  # Active course
@@ -111,6 +113,11 @@ LEXICON = {
     "status_finished": "finished",  # Course has ended
 
     "sheet_updated": "✅ Spreadsheet updated.",
+
+    # Ownership transfer flow
+    "ownership_email_request": "Enter Google account email to transfer ownership:",
+    "ownership_transfer_success": "✅ Ownership transferred.",
+    "ownership_transfer_failed": "❌ Could not transfer ownership: {error}",
 
     # endregion --- Admin Panel ---
 

--- a/services/course_service.py
+++ b/services/course_service.py
@@ -1,7 +1,21 @@
-from database.crud_courses import create_course, add_participants, set_rate
+import logging
+from sqlalchemy import select
+
+from database.crud_courses import (
+    create_course as create_course_record,
+    add_participants,
+    set_rate,
+)
 from services.utils import gen_registration_code
+from services.google_sheets import (
+    create_course_sheet,
+    fetch_students,
+    write_registration_codes,
+)
 from database.base import AsyncSessionLocal
-from database.models import Course
+from database.models import Course, Participant
+
+logger = logging.getLogger(__name__)
 
 
 async def create_course_with_participants(
@@ -31,7 +45,7 @@ async def create_course_with_participants(
 
     # Persist course and participants
     async with AsyncSessionLocal() as session:
-        course = await create_course(
+        course = await create_course_record(
             session,
             name=name,
             description=description,
@@ -43,3 +57,69 @@ async def create_course_with_participants(
         await set_rate(session, course.id, "loan", loan_rate)
 
     return course, codes_map
+
+
+async def create_course(
+        name: str,
+        description: str,
+        creator_id: int,
+        savings_rate: float,
+        loan_rate: float,
+) -> Course:
+    """Create a course and its spreadsheet."""
+    sheet_url = create_course_sheet(name)
+    async with AsyncSessionLocal() as session:
+        course = await create_course_record(
+            session,
+            name=name,
+            description=description,
+            creator_id=creator_id,
+            sheet_url=sheet_url,
+        )
+        await set_rate(session, course.id, "savings", savings_rate)
+        await set_rate(session, course.id, "loan", loan_rate)
+    return course
+
+
+async def sync_participants_from_sheet(course_id: int) -> int:
+    """Add new participants from the course sheet and assign registration codes."""
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        result = await session.execute(
+            select(Participant).where(Participant.course_id == course_id)
+        )
+        participants = result.scalars().all()
+        existing_emails = {p.email.strip().lower() for p in participants}
+        existing_codes = {p.registration_code for p in participants}
+        sheet_url = course.sheet_url
+
+    try:
+        students = fetch_students(sheet_url)
+    except Exception as e:  # pragma: no cover - external API errors
+        logger.exception("Failed to read students for course %s", course_id)
+        raise e
+
+    new_participants = []
+    codes_map: dict[str, str] = {}
+
+    for name_, email in students:
+        email_lc = email.strip().lower()
+        if email_lc in existing_emails:
+            continue
+        code = gen_registration_code(existing_codes)
+        existing_codes.add(code)
+        new_participants.append({
+            "name": name_,
+            "email": email,
+            "registration_code": code,
+        })
+        codes_map[email] = code
+
+    if not new_participants:
+        return 0
+
+    async with AsyncSessionLocal() as session:
+        await add_participants(session, course_id, new_participants)
+
+    write_registration_codes(sheet_url, codes_map)
+    return len(new_participants)

--- a/states/fsm.py
+++ b/states/fsm.py
@@ -8,7 +8,6 @@ class CourseCreation(StatesGroup):
     waiting_for_description = State()
     waiting_for_savings_rate = State()
     waiting_for_loan_rate = State()
-    waiting_for_sheet = State()
 
 
 class CourseEdit(StatesGroup):
@@ -20,6 +19,10 @@ class CourseEdit(StatesGroup):
     waiting_for_loan_rate = State()
     waiting_for_max_loan = State()
     waiting_for_savings_lock = State()
+
+
+class CourseOwnership(StatesGroup):
+    waiting_for_email = State()
 
 
 class Registration(StatesGroup):


### PR DESCRIPTION
## Summary
- auto-create and configure course spreadsheets
- add RegCode generation and ownership transfer controls
- support syncing new participants from sheets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a5124a9248333879ede12d24d8ae7