### PR TITLE
Rename balance to wallet across project

### DIFF
--- a/database/crud_courses.py
+++ b/database/crud_courses.py
@@ -86,27 +86,29 @@ async def add_participants(
 
 
 class CourseStats(TypedDict):
+    """Aggregated statistics for a course."""
+
     total: int
     registered: int
-    avg_balance: float
+    avg_wallet_balance: float
 
 
 async def get_course_stats(
         session: AsyncSession,
         course_id: int
 ) -> CourseStats:
-    """Compute stats: total participants, registered count, average balance."""
+    """Compute stats: total participants, registered count, average wallet balance."""
     stmt = select(
         func.count(Participant.id),
         func.sum(case((Participant.is_registered, 1), else_=0)),
-        func.avg(Participant.balance)
+        func.avg(Participant.wallet_balance)
     ).where(Participant.course_id == course_id)
 
-    total, registered, avg_balance = (await session.execute(stmt)).one()
+    total, registered, avg_wallet_balance = (await session.execute(stmt)).one()
     return CourseStats(
         total=total,
         registered=registered,
-        avg_balance=float(avg_balance or 0.0)
+        avg_wallet_balance=float(avg_wallet_balance or 0.0)
     )
 
 

--- a/database/crud_participant.py
+++ b/database/crud_participant.py
@@ -56,21 +56,17 @@ async def register_participant(
     return participant
 
 
-async def adjust_participant_balance(
+async def adjust_wallet_balance(
         session: AsyncSession,
         participant: Participant,
         delta: float | Decimal
 ) -> Participant:
-    """
-    Adjust main wallet balance by the given delta (can be fractional).
-    Rounds to 2 decimals.
-    """
-    # Ensure Decimal
+    """Adjust wallet balance by the given delta rounded to 2 decimals."""
     change = Decimal(delta)
-    new_balance = (participant.balance + change).quantize(
+    new_balance = (participant.wallet_balance + change).quantize(
         Decimal("0.01"), rounding=ROUND_HALF_UP
     )
-    participant.balance = new_balance
+    participant.wallet_balance = new_balance
     await session.commit()
     await session.refresh(participant)
     return participant

--- a/database/models.py
+++ b/database/models.py
@@ -34,6 +34,7 @@ class Course(Base):
 
 class Participant(Base):
     __tablename__ = "participants"
+    """Database model representing a course participant."""
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     course_id = Column(Integer, ForeignKey("courses.id"), nullable=False)
@@ -43,12 +44,12 @@ class Participant(Base):
     telegram_id = Column(BigInteger, nullable=True)
     is_registered = Column(Boolean, default=False)
 
-    # Balances support 2 decimal places, up to 6 digits before the point
-    balance = Column(Numeric(8, 2), default=0)
+    # Account balances support 2 decimal places, up to 6 digits before the point
+    wallet_balance = Column(Numeric(8, 2), default=0)
     savings_balance = Column(Numeric(8, 2), default=0)
     loan_balance = Column(Numeric(8, 2), default=0)
 
-    # timestamp of last deposit to savings to enforce withdrawal delay
+    # Timestamp of last deposit to savings to enforce withdrawal delay
     last_savings_deposit_at = Column(DateTime, nullable=True)
 
     course = relationship("Course", back_populates="participants")

--- a/handlers/participant.py
+++ b/handlers/participant.py
@@ -282,7 +282,7 @@ async def ask_to_savings(callback: CallbackQuery, state: FSMContext):
 
 @participant_router.message(StateFilter(CashOperations.waiting_for_savings_deposit_amount))
 async def process_to_savings(message: Message, state: FSMContext):
-    """Move funds from main balance to savings."""
+    """Move funds from wallet to savings."""
     text = message.text.strip()
     try:
         amount = Decimal(text)
@@ -334,7 +334,7 @@ async def ask_from_savings(callback: CallbackQuery, state: FSMContext):
 
 @participant_router.message(StateFilter(CashOperations.waiting_for_savings_withdraw_amount))
 async def process_from_savings(message: Message, state: FSMContext):
-    """Withdraw funds from savings back to main balance."""
+    """Withdraw funds from savings back to wallet."""
     text = message.text.strip()
     try:
         amount = Decimal(text)

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -47,7 +47,7 @@ LEXICON = {
 
     # region --- Participant Registration ---
 
-    # "participant_greeting": "Welcome! Available commands: /balance, /deposit, /withdraw",  # Initial greeting
+    # "participant_greeting": "Welcome! Available commands: /wallet, /deposit, /withdraw",  # Initial greeting
     "registration_code_request": "Enter your registration code:",  # Ask for code
     # "registration_welcome": 'To join a course, enter your registration code:',  # /start flow
     "registration_not_found": "❌ Code not found. Please check and try again.",  # Invalid code
@@ -103,7 +103,7 @@ LEXICON = {
         "📆 Interest payout: {interest_day} {interest_time} UTC\n\n"
         "👥 Total participants: {total}\n"
         "📝 Registered: {registered}\n"
-        "💳 Average balance: {avg_balance:.2f}"
+        "💳 Average wallet balance: {avg_wallet_balance:.2f}"
     ),
 
     # Status Values
@@ -119,11 +119,11 @@ LEXICON = {
     # Participant Main Menu and Display
     "choose_course_prompt": "Please choose your course:",
 
-    "main_balance_text": (
+    "main_wallet_text": (
         "🏫 Course: {course_name}\n"
         "👤 {name}\n\n"
-        "<b>🪙 Total: {total:.2f}</b>\n\n"
-        "💳 Balance: {balance}\n"
+        "<b>🪙 Total: {total_balance:.2f}</b>\n\n"
+        "💳 Wallet: {wallet}\n"
         "💹 Savings: {savings} (rate: {savings_rate}% weekly)\n"
         "💸 Loans: {loan} (rate: {loan_rate}% weekly)\n"
     ),  # Overview of participant balances
@@ -187,7 +187,7 @@ LEXICON = {
                          "<code>{course_name}, {name}, tx_id: {tx_id}</code>",
     "withdraw_declined": "❌ Your withdrawal request of {amount} 🪙 has been declined.\n"
                          "<code>{course_name}, {name}, tx_id: {tx_id}</code>",
-    "deposit_approved": "✅ Your deposit of {amount} 🪙 has been approved and added to your balance.\n"
+    "deposit_approved": "✅ Your deposit of {amount} 🪙 has been approved and added to your wallet.\n"
                         "<code>{course_name}, {name}, tx_id: {tx_id}</code>",
     "deposit_declined": "❌ Your deposit request of {amount} 🪙 has been declined.\n"
                         "<code>{course_name}, {name}, tx_id: {tx_id}</code>",

--- a/services/google_sheets.py
+++ b/services/google_sheets.py
@@ -62,7 +62,7 @@ def mark_registered(sheet_url: str, email: str) -> None:
 async def _collect_balance_data(
     session: AsyncSession, course_id: int
 ) -> tuple[str, dict[str, tuple[float, float, float, float]]]:
-    """Collect balance data for all course participants."""
+    """Collect wallet, savings and loan data for all course participants."""
     course = await session.get(Course, course_id)
     result = await session.execute(
         select(Participant).where(Participant.course_id == course_id)
@@ -71,12 +71,12 @@ async def _collect_balance_data(
 
     data: dict[str, tuple[float, float, float, float]] = {}
     for p in participants:
-        balance = Decimal(p.balance) if p.balance is not None else Decimal("0")
+        wallet = Decimal(p.wallet_balance) if p.wallet_balance is not None else Decimal("0")
         savings = Decimal(p.savings_balance) if p.savings_balance is not None else Decimal("0")
         loan = Decimal(p.loan_balance) if p.loan_balance is not None else Decimal("0")
-        total = balance + savings - loan
+        total_balance = wallet + savings - loan
         data[p.email.strip().lower()] = (
-            float(total), float(balance), float(savings), float(loan)
+            float(total_balance), float(wallet), float(savings), float(loan)
         )
 
     return course.sheet_url, data
@@ -85,11 +85,11 @@ async def _collect_balance_data(
 def _write_balances_to_sheet(
     sheet_url: str, data: dict[str, tuple[float, float, float, float]]
 ) -> None:
-    """Write balances into the course Google Sheet."""
+    """Write wallet, savings and loan balances into the course Google Sheet."""
     ss_id = _normalize_url(sheet_url)
     sheet = _gs_client.open_by_key(ss_id).sheet1
     # Header row
-    sheet.update("F1:I1", [["Total", "Balance", "Savings", "Loan"]])
+    sheet.update("F1:I1", [["Total", "Wallet", "Savings", "Loan"]])
     records = sheet.get_all_records()
     for idx, row in enumerate(records, start=2):
         email = row.get("Email", "").strip().lower()
@@ -98,7 +98,7 @@ def _write_balances_to_sheet(
 
 
 async def update_course_balances(course_id: int) -> None:
-    """Update a course's Google Sheet with participant balances."""
+    """Update a course's Google Sheet with participant wallet/savings/loan balances."""
     async with AsyncSessionLocal() as session:
         sheet_url, data = await _collect_balance_data(session, course_id)
 

--- a/services/participant_menu.py
+++ b/services/participant_menu.py
@@ -20,8 +20,7 @@ async def build_participant_menu(
         if not participant:
             text = "Participant not found or not registered."
             return text, InlineKeyboardMarkup()
-
-        balance = participant.balance
+        wallet = participant.wallet_balance
         savings = participant.savings_balance
         loan = participant.loan_balance
         savings_rate = await get_current_rate(session, participant.course_id, "savings")
@@ -30,7 +29,7 @@ async def build_participant_menu(
     text = render_participant_info(
         participant_name,
         course_name,
-        balance,
+        wallet,
         savings,
         loan,
         savings_rate,

--- a/services/presenters.py
+++ b/services/presenters.py
@@ -26,7 +26,7 @@ def render_course_info(course, stats: dict, savings_rate: float, loan_rate: floa
         sheet_url=course.sheet_url or "-",
         total=stats["total"],
         registered=stats["registered"],
-        avg_balance=stats["avg_balance"],
+        avg_wallet_balance=stats["avg_wallet_balance"],
         savings_rate=savings_rate,
         loan_rate=loan_rate,
         max_loan=course.max_loan_amount,
@@ -39,22 +39,22 @@ def render_course_info(course, stats: dict, savings_rate: float, loan_rate: floa
 def render_participant_info(
     name: str,
     course_name: str,
-    balance,
+    wallet,
     savings,
     loan,
     savings_rate: float,
     loan_rate: float,
 ) -> str:
-    """Compose a text snippet with the participant's balances."""
-    return LEXICON["main_balance_text"].format(
+    """Compose a text snippet with the participant's wallet, savings and loan balances."""
+    return LEXICON["main_wallet_text"].format(
         name=name,
         course_name=course_name,
-        balance=balance,
+        wallet=wallet,
         savings=savings,
         loan=loan,
         savings_rate=savings_rate,
         loan_rate=loan_rate,
-        total=balance + savings - loan,
+        total_balance=wallet + savings - loan,
     )
 
 def render_admin_menu(active: int, finished: int) -> str:


### PR DESCRIPTION
## Summary
- rename participant balance to wallet balance and adjust related calculations
- update services and handlers to use wallet terminology and total balance
- refresh lexicon entries to reference wallet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8a40ff008333aac1da7fdd99e20e