### PR TITLE
Refactor course creation and sheet setup

### DIFF
--- a/config_data/config.py
+++ b/config_data/config.py
@@ -16,6 +16,7 @@ class Config:
     db: DB
     SERVICE_ACCOUNT_FILE: str
     POSTMARK_API_TOKEN: str
+    SHEET_EDITOR_EMAIL: str
 
 
 def load_config(path: str | None = None) -> Config:
@@ -33,5 +34,6 @@ def load_config(path: str | None = None) -> Config:
             # url="sqlite+aiosqlite:////db/makerbank.db"
         ),
         SERVICE_ACCOUNT_FILE="service_account.json",
-        POSTMARK_API_TOKEN = env('POSTMARK_API_TOKEN')
+        POSTMARK_API_TOKEN=env('POSTMARK_API_TOKEN'),
+        SHEET_EDITOR_EMAIL="service_bot@email.com",
     )

--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -87,6 +87,12 @@ def course_actions_kb(course_id: int) -> InlineKeyboardMarkup:
         ],
         [
             InlineKeyboardButton(
+                text=LEXICON["button_sync_users"],
+                callback_data=f"admin:course:sync:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
                 text=LEXICON["button_update_sheet"],
                 callback_data=f"admin:course:update_sheet:{course_id}"
             ),

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -21,20 +21,29 @@ LEXICON = {
     "course_interest_day_request": "Enter interest payout weekday (0=Monday ... 6=Sunday):",
     "course_interest_time_request": "Enter interest payout time (HH:MM, UTC):",
     "course_value_invalid": "Please enter a valid number.",
-    "course_sheet_request": "Please send the Google Sheets link containing the list of participants:",
-    # Ask for sheet URL
+    "course_sheet_request": (
+        "Create a new blank Google Spreadsheet, add {email} as an editor and send the link here.\n"
+        "⚠️ All data on the first sheet will be removed."
+    ),  # Ask for sheet URL
 
     # Errors related to Google Sheets
     "course_sheet_invalid": "❌ Failed to read data from Google Sheets. Please check the link and try again.",
     "course_sheet_invalid_format": "❗️ It seems this is not a Google Sheets link. Please send a valid link.",
-    "course_sheet_unreachable": "❌ Could not access the sheet. Make sure you have granted access to the service "
-                                "account.",
-    "course_sheet_empty": "⚠️ The sheet is empty or doesn't contain the columns 'Name' and 'Email'. Please check its "
-                          "contents.",
+    "course_sheet_unreachable": (
+        "❌ Could not access the sheet. Make sure you have granted access to the service account."
+    ),
+    "course_sheet_empty": (
+        "⚠️ The sheet is empty or doesn't contain the columns 'Name' and 'Email'. Please check its contents."
+    ),
+    "course_sheet_setup_error": (
+        "Ensure you added {email} as an editor and send the link again."
+    ),
 
     # Confirmation once a course is created
-    "course_created": "✅ Course “{name}” created, {count} participants added. Registration codes have been written to "
-                      "the Google Sheets.",
+    "course_created": (
+        "✅ Course “{name}” created! Add participants to this table, then press "
+        "“Add Users & Check Registration” in the course card."
+    ),
 
     # Finish Course Flow
     "finish_no_active": "You have no active courses to finish.",
@@ -83,6 +92,7 @@ LEXICON = {
     "button_edit_loan_rate": "💸 Loan rate",
     "button_edit_max_loan": "⬆️ Max loan",
     "button_edit_savings_lock": "⏳ Savings lock",
+    "button_sync_users": "👥 Add Users & Check Registration",
     "button_update_sheet": "🔄 Update Spreadsheet",
 
     # Emojis indicating course status
@@ -111,6 +121,23 @@ LEXICON = {
     "status_finished": "finished",  # Course has ended
 
     "sheet_updated": "✅ Spreadsheet updated.",
+    "course_users_synced": (
+        "✅ Processed. {new} new participants added. Registration statuses updated."
+    ),
+
+    # Column headers for course spreadsheets
+    "sheet_header_name": "Name",
+    "sheet_header_email": "Email",
+    "sheet_header_comment": "Comment",
+    "sheet_header_reg_code": "RegCode",
+    "sheet_header_registered": "Registered",
+    "sheet_header_total": "Total",
+    "sheet_header_wallet": "Wallet",
+    "sheet_header_savings": "Savings",
+    "sheet_header_loan": "Loan",
+    "sheet_protected_warning": (
+        "Do not edit this unless you absolutely know what you are doing."
+    ),
 
     # endregion --- Admin Panel ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ environs
 SQLAlchemy>=1.4
 aiosqlite
 gspread>=5.0.0
+gspread-formatting>=1.0.0
 google-auth>=2.0.0
 oauth2client>=4.1.3
 postmarker

--- a/services/course_service.py
+++ b/services/course_service.py
@@ -1,7 +1,11 @@
+from sqlalchemy import select
+
 from database.crud_courses import create_course, add_participants, set_rate
 from services.utils import gen_registration_code
 from database.base import AsyncSessionLocal
-from database.models import Course
+from database.models import Course, Participant
+from services.google_sheets import fetch_students, write_registration_codes, mark_registered
+from lexicon.lexicon_en import LEXICON
 
 
 async def create_course_with_participants(
@@ -43,3 +47,49 @@ async def create_course_with_participants(
         await set_rate(session, course.id, "loan", loan_rate)
 
     return course, codes_map
+
+
+async def sync_course_participants(course_id: int) -> int:
+    """Synchronize Google Sheet participants with the database."""
+    async with AsyncSessionLocal() as session:
+        course = await session.get(Course, course_id)
+        rows = fetch_students(course.sheet_url)
+
+        result = await session.execute(
+            select(Participant.email, Participant.registration_code, Participant.is_registered)
+            .where(Participant.course_id == course_id)
+        )
+        existing = {
+            email.lower(): (code, is_registered)
+            for email, code, is_registered in result
+        }
+        existing_codes = {data[0] for data in existing.values()}
+
+        new_participants: list[dict[str, str]] = []
+        codes_map: dict[str, str] = {}
+
+        for row in rows:
+            name = row.get(LEXICON["sheet_header_name"], "").strip()
+            email = row.get(LEXICON["sheet_header_email"], "").strip()
+            if not name or not email or email.lower() in existing:
+                continue
+            code = gen_registration_code(existing_codes)
+            existing_codes.add(code)
+            new_participants.append({
+                "name": name,
+                "email": email,
+                "registration_code": code,
+            })
+            codes_map[email] = code
+
+        if new_participants:
+            await add_participants(session, course_id, new_participants)
+
+        registered_emails = {
+            email for email, data in existing.items() if data[1]
+        }
+
+    write_registration_codes(course.sheet_url, codes_map)
+    for email in registered_emails:
+        mark_registered(course.sheet_url, email)
+    return len(codes_map)


### PR DESCRIPTION
## Summary
- prepare new course spreadsheets with headers, checkboxes and protected columns
- ask admins to create a blank sheet and provide its link for new courses
- add “Add Users & Check Registration” button to sync participants from sheet

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement gspread-formatting>=1.0.0)*
- `python -m py_compile config_data/config.py handlers/admin.py keyboards/admin.py lexicon/lexicon_en.py services/course_creation_flow.py services/course_service.py services/google_sheets.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b1a2698908333bb8498796545cde3