### PR TITLE
feat: send registration codes via Postmark

### DIFF
--- a/keyboards/admin.py
+++ b/keyboards/admin.py
@@ -93,6 +93,12 @@ def course_actions_kb(course_id: int) -> InlineKeyboardMarkup:
         ],
         [
             InlineKeyboardButton(
+                text=LEXICON["button_send_regcodes"],
+                callback_data=f"admin:course:send_regcodes:{course_id}"
+            ),
+        ],
+        [
+            InlineKeyboardButton(
                 text=LEXICON["button_update_sheet"],
                 callback_data=f"admin:course:update_sheet:{course_id}"
             ),

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -93,6 +93,7 @@ LEXICON = {
     "button_edit_max_loan": "⬆️ Max loan",
     "button_edit_savings_lock": "⏳ Savings lock",
     "button_sync_users": "👥 Add Users & Check Registration",
+    "button_send_regcodes": "✉️ Send RegCodes",
     "button_update_sheet": "🔄 Update Spreadsheet",
 
     # Emojis indicating course status
@@ -123,6 +124,16 @@ LEXICON = {
     "sheet_updated": "✅ Spreadsheet updated.",
     "course_users_synced": (
         "✅ Processed. {new} new participants added. Registration statuses updated."
+    ),
+    "course_regcodes_sent": (
+        "✅ Sent registration codes to {count} participants."
+    ),
+    "course_regcodes_error": (
+        "❌ Failed to send registration codes."
+    ),
+    "email_regcode_subject": "Daily Maker Bank Bot: {course}",
+    "email_regcode_body": (
+        "Hello {name}! Please use registration code {code} to register in the bot."
     ),
 
     # Column headers for course spreadsheets

--- a/services/email_service.py
+++ b/services/email_service.py
@@ -1,0 +1,34 @@
+"""Utilities for sending emails."""
+
+import logging
+from postmarker.core import PostmarkClient
+
+from config_data import config
+from lexicon.lexicon_en import LEXICON
+
+logger = logging.getLogger(__name__)
+_client = PostmarkClient(server_token=config.POSTMARK_API_TOKEN)
+_SENDER = "no-reply@dmitryyakovlev.space"
+
+
+def send_registration_code(recipient: str, code: str, course: str, name: str) -> None:
+    """Send a registration code email.
+
+    Args:
+        recipient: Email address of the participant.
+        code: Registration code to deliver.
+        course: Name of the course.
+        name: Participant's name.
+
+    Raises:
+        Exception: Propagates errors from the Postmark client.
+    """
+    subject = LEXICON["email_regcode_subject"].format(course=course)
+    body = LEXICON["email_regcode_body"].format(name=name, code=code)
+    _client.emails.send(
+        From=_SENDER,
+        To=recipient,
+        Subject=subject,
+        HtmlBody=f"<p>{body}</p>",
+    )
+    logger.debug("Email accepted for %s", recipient)


### PR DESCRIPTION
## Summary
- add Postmark helper to dispatch registration codes
- allow admins to email reg codes to unregistered participants
- expose course menu button for sending registration codes
- personalize email subject and body with course and participant details
- rename Postmark service to generic email service

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b2aa1dc388333a65729071ae1ede8