### PR TITLE
Disallow registration for finished courses

### DIFF
--- a/database/crud_participant.py
+++ b/database/crud_participant.py
@@ -38,7 +38,9 @@ async def get_participant_by_code(
 ) -> Participant | None:
     """Fetch a participant by their registration code."""
     result = await session.execute(
-        select(Participant).where(Participant.registration_code == code)
+        select(Participant)
+        .options(selectinload(Participant.course))
+        .where(Participant.registration_code == code)
     )
     return result.scalar_one_or_none()
 

--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -67,6 +67,16 @@ async def process_registration_code(message: Message, state: FSMContext):
         await state.clear()
         return
 
+    if status == "finished":
+        await message.answer(
+            LEXICON["registration_course_finished"].format(
+                name=part.course.name
+            ),
+            parse_mode="HTML",
+        )
+        await state.clear()
+        return
+
     # Successfully registered
     await message.answer(
         LEXICON["registration_success"].format(name=part.name),

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -61,6 +61,7 @@ LEXICON = {
     # "registration_welcome": 'To join a course, enter your registration code:',  # /start flow
     "registration_not_found": "❌ Code not found. Please check and try again.",  # Invalid code
     "registration_already": "⚠️ You are already registered, {name}.",  # Already registered
+    "registration_course_finished": "🛑 Course “{name}” is already finished. Registration is closed.",
     "registration_success": "✅ You have been registered as {name}! Welcome.\n\n"
                             "Now you can use /start to access your banking menu.",  # Success
 

--- a/services/participant_registration.py
+++ b/services/participant_registration.py
@@ -3,11 +3,25 @@ from database.crud_participant import get_participant_by_code, register_particip
 
 
 async def register_by_code(code: str, telegram_id: int):
-    """Register a participant using a code, returning (participant, status)."""
+    """Register a participant using a code, returning (participant, status).
+
+    Args:
+        code: Registration code provided by the user.
+        telegram_id: Telegram identifier of the user.
+
+    Returns:
+        tuple: A pair ``(participant, status)`` where status is one of:
+            - ``"not_found"``: code does not exist.
+            - ``"already"``: participant already registered.
+            - ``"finished"``: course has been finished.
+            - ``"ok"``: registration successful.
+    """
     async with AsyncSessionLocal() as session:
         part = await get_participant_by_code(session, code)
         if not part:
             return None, "not_found"
+        if part.course and not part.course.is_active:
+            return part, "finished"
         if part.is_registered:
             return part, "already"
         part = await register_participant(session, part, telegram_id)


### PR DESCRIPTION
## Summary
- prevent participant registration if their course is finished
- inform users with new lexicon message when a course is completed

## Testing
- `python -m py_compile database/crud_participant.py services/participant_registration.py handlers/registration.py lexicon/lexicon_en.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b3b398e548333b65290ad323a6fec