### PR TITLE
Handle NaN amounts in savings and loan flows

### DIFF
--- a/handlers/participant.py
+++ b/handlers/participant.py
@@ -292,6 +292,12 @@ async def process_to_savings(message: Message, state: FSMContext):
             parse_mode="HTML",
             reply_markup=cancel_operation_kb(),
         )
+    if amount.is_nan():
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
     amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
     if amount <= 0:
         return await message.answer(
@@ -339,6 +345,12 @@ async def process_from_savings(message: Message, state: FSMContext):
     try:
         amount = Decimal(text)
     except (InvalidOperation, ValueError):
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
+    if amount.is_nan():
         return await message.answer(
             LEXICON["invalid_amount"],
             parse_mode="HTML",
@@ -399,6 +411,12 @@ async def process_take_loan(message: Message, state: FSMContext):
             parse_mode="HTML",
             reply_markup=cancel_operation_kb(),
         )
+    if amount.is_nan():
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
     amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
     if amount <= 0:
         return await message.answer(
@@ -446,6 +464,12 @@ async def process_repay_loan(message: Message, state: FSMContext):
     try:
         amount = Decimal(text)
     except (InvalidOperation, ValueError):
+        return await message.answer(
+            LEXICON["invalid_amount"],
+            parse_mode="HTML",
+            reply_markup=cancel_operation_kb(),
+        )
+    if amount.is_nan():
         return await message.answer(
             LEXICON["invalid_amount"],
             parse_mode="HTML",

--- a/services/banking.py
+++ b/services/banking.py
@@ -99,7 +99,10 @@ async def move_to_savings(participant_id: int, amount: Decimal | float) -> None:
     """Transfer amount from wallet to savings immediately."""
     async with AsyncSessionLocal() as session:
         participant = await session.get(Participant, participant_id)
-        amount = Decimal(amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        amount = Decimal(amount)
+        if amount.is_nan():
+            raise ValueError(LEXICON["invalid_amount"])
+        amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         if amount <= 0:
             raise ValueError(LEXICON["invalid_amount"])
         if amount > participant.wallet_balance:
@@ -121,7 +124,10 @@ async def withdraw_from_savings(participant_id: int, amount: Decimal | float) ->
     async with AsyncSessionLocal() as session:
         participant = await session.get(Participant, participant_id)
         course = await session.get(Course, participant.course_id)
-        amount = Decimal(amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        amount = Decimal(amount)
+        if amount.is_nan():
+            raise ValueError(LEXICON["invalid_amount"])
+        amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         if amount <= 0:
             raise ValueError(LEXICON["invalid_amount"])
         if amount > participant.savings_balance:
@@ -147,7 +153,10 @@ async def take_loan(participant_id: int, amount: Decimal | float) -> None:
     async with AsyncSessionLocal() as session:
         participant = await session.get(Participant, participant_id)
         course = await session.get(Course, participant.course_id)
-        amount = Decimal(amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        amount = Decimal(amount)
+        if amount.is_nan():
+            raise ValueError(LEXICON["invalid_amount"])
+        amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         if amount <= 0:
             raise ValueError(LEXICON["invalid_amount"])
         if participant.loan_balance + amount > course.max_loan_amount:
@@ -170,7 +179,10 @@ async def repay_loan(participant_id: int, amount: Decimal | float) -> None:
     """Repay part of the loan from wallet."""
     async with AsyncSessionLocal() as session:
         participant = await session.get(Participant, participant_id)
-        amount = Decimal(amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        amount = Decimal(amount)
+        if amount.is_nan():
+            raise ValueError(LEXICON["invalid_amount"])
+        amount = amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         if amount <= 0:
             raise ValueError(LEXICON["invalid_amount"])
         if amount > participant.wallet_balance:


### PR DESCRIPTION
## Summary
- validate numeric input to reject NaN values in savings deposit/withdrawal and loan borrow/repay handlers
- guard banking service methods against NaN amounts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac6c3a0eb08333b4ad8d0284ec9c34