### PR TITLE
Log user messages and IDs

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -3,6 +3,7 @@ from aiogram import Bot, Dispatcher
 from config_data import config
 from handlers import register_handlers
 from keyboards.main_menu import get_main_menu_commands
+from middlewares.logging_middleware import LoggingMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,7 @@ def create_bot() -> Bot:
 def create_dispatcher() -> Dispatcher:
     """Create dispatcher and register all handlers."""
     dp = Dispatcher()
+    dp.update.outer_middleware(LoggingMiddleware())
     register_handlers(dp)
     return dp
 

--- a/middlewares/logging_middleware.py
+++ b/middlewares/logging_middleware.py
@@ -1,0 +1,45 @@
+import logging
+from aiogram import BaseMiddleware
+from aiogram.types import Update
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingMiddleware(BaseMiddleware):
+    """Middleware for logging user messages and identifiers."""
+
+    async def __call__(self, handler, event: Update, data: dict):
+        """Process an update and log message text with user id.
+
+        Args:
+            handler: Next middleware or handler in the chain.
+            event: Incoming update instance.
+            data: Contextual data for the handler.
+
+        Returns:
+            Any: Result returned by the next handler.
+        """
+        message = None
+        user_id = None
+        text = None
+
+        if getattr(event, "message", None):
+            message = event.message
+        elif getattr(event, "edited_message", None):
+            message = event.edited_message
+        elif getattr(event, "callback_query", None):
+            callback = event.callback_query
+            message = callback.message
+            text = callback.data
+            user_id = callback.from_user.id
+
+        if message is not None:
+            if text is None:
+                text = message.text or message.caption or ""
+            if user_id is None and getattr(message, "from_user", None):
+                user_id = message.from_user.id
+
+        if text is not None and user_id is not None:
+            logger.info("Update from %s: %s", user_id, text)
+
+        return await handler(event, data)


### PR DESCRIPTION
## Summary
- Add middleware to log user message text and Telegram ID
- Register logging middleware in dispatcher

## Testing
- `python -m py_compile core/bot.py middlewares/logging_middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac71a3938083338bc77cc68b81a2bb