### PR TITLE
feat: add telegram columns to course sheet

### DIFF
--- a/handlers/registration.py
+++ b/handlers/registration.py
@@ -6,6 +6,7 @@ from aiogram.types import Message
 from filters.role_filter import RoleFilter
 from lexicon.lexicon_en import LEXICON
 from services.participant_registration import register_by_code
+from services.google_sheets import mark_registered
 from states.fsm import Registration
 
 # Router for registration flows
@@ -78,6 +79,12 @@ async def process_registration_code(message: Message, state: FSMContext):
         return
 
     # Successfully registered
+    mark_registered(
+        part.course.sheet_url,
+        part.email,
+        message.from_user.id,
+        message.from_user.username,
+    )
     await message.answer(
         LEXICON["registration_success"].format(name=part.name),
         parse_mode="HTML",

--- a/lexicon/lexicon_en.py
+++ b/lexicon/lexicon_en.py
@@ -142,6 +142,8 @@ LEXICON = {
     "sheet_header_name": "Name",
     "sheet_header_email": "Email",
     "sheet_header_comment": "Comment",
+    "sheet_header_tg_id": "TG ID",
+    "sheet_header_tg_nickname": "TG Nickname",
     "sheet_header_reg_code": "RegCode",
     "sheet_header_registered": "Registered",
     "sheet_header_total": "Total",


### PR DESCRIPTION
## Summary
- add TG ID and nickname headers in course spreadsheets
- capture Telegram info on registration and mark registration in sheet
- extend sheet setup and balance updates for new columns

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac7de9761c8333b232e67024c15567